### PR TITLE
Fix: Add use GuidHelper in compiler

### DIFF
--- a/libraries/vendor_jcb/VDM.Joomla/src/Componentbuilder/Compiler/Creator/FieldXML.php
+++ b/libraries/vendor_jcb/VDM.Joomla/src/Componentbuilder/Compiler/Creator/FieldXML.php
@@ -28,6 +28,7 @@ use VDM\Joomla\Utilities\StringHelper;
 use VDM\Joomla\Utilities\String\FieldHelper;
 use VDM\Joomla\Utilities\ArrayHelper;
 use VDM\Joomla\Utilities\ObjectHelper;
+use VDM\Joomla\Utilities\GuidHelper;
 use VDM\Joomla\Componentbuilder\Compiler\Utilities\Line;
 use VDM\Joomla\Componentbuilder\Compiler\Interfaces\Creator\Fieldtypeinterface;
 


### PR DESCRIPTION
Issue: gh-1277

When creating a subform and linking a structured field inside it (for example, an SQL field or other structured/dynamic fields), the Joomla Component Builder compiler throws a fatal error and stops the compilation process.

The expected behavior is that the compiler correctly handles structured fields inside subforms and completes the component compilation without errors.

Compiler error returned:

Class "VDM\Joomla\Componentbuilder\Compiler\Creator\GuidHelper" not found 

This error suggests that a required dependency is missing or not properly loaded during the subform field normalization process.

Steps to reproduce the Bug
Create a subform with a fieldCreate a new Subform field in Joomla Component Builder.
Inside the subform, add a structured field (e.g. an SQL field or another structured/dynamic field).
Save the field and include it in a fieldset or view of the component.
Start the component compilation process.
The compiler stops and returns the following error:
Class "VDM\Joomla\Componentbuilder\Compiler\Creator\GuidHelper" not found
The compilation fails and the component is not generated.

